### PR TITLE
Markdown rendering for job description

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -395,12 +395,12 @@ fieldset {
   padding: 0;
 }
 
-ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+/* ol, */
+/* ul { */
+/*   list-style: none; */
+/*   margin: 0; */
+/*   padding: 0; */
+/* } */
 
 /**
  * Tailwind custom reset styles
@@ -501,15 +501,15 @@ table {
   border-collapse: collapse;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
-}
+/* h1, */
+/* h2, */
+/* h3, */
+/* h4, */
+/* h5, */
+/* h6 { */
+/*   font-size: inherit; */
+/*   font-weight: inherit; */
+/* } */
 
 /**
  * Reset links to optimize for opt-in styling instead of
@@ -517,8 +517,16 @@ h6 {
  */
 
 a {
-  color: inherit;
   text-decoration: inherit;
+  color: rgba(220,121,0,1);
+}
+
+a:hover, a:active {
+  text-decoration: underline;
+}
+
+header a:hover {
+  text-decoration: none;
 }
 
 /**
@@ -106686,4 +106694,3 @@ video {
             animation: bounce 1s infinite;
   }
 }
-

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -359,21 +359,21 @@ template {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-hr,
-figure,
-p,
-pre {
-  margin: 0;
-}
+/* blockquote, */
+/* dl, */
+/* dd, */
+/* h1, */
+/* h2, */
+/* h3, */
+/* h4, */
+/* h5, */
+/* h6, */
+/* hr, */
+/* figure, */
+/* p, */
+/* pre { */
+/*   margin: 0; */
+/* } */
 
 button {
   background-color: transparent;

--- a/data.go
+++ b/data.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/mail"
 	"net/url"
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 )
 
 // data
@@ -32,6 +36,30 @@ func (job *Job) update(newParams NewJob) {
 
 	job.Description.String = newParams.Description
 	job.Description.Valid = newParams.Description != ""
+}
+
+func (job *Job) RenderDescription() (string, error) {
+	if !job.Description.Valid {
+		return "", nil
+	}
+
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			extension.NewLinkify(
+				extension.WithLinkifyAllowedProtocols([][]byte{
+					[]byte("http:"),
+					[]byte("https:"),
+				}),
+			),
+		),
+	)
+
+	var b bytes.Buffer
+	if err := markdown.Convert([]byte(job.Description.String), &b); err != nil {
+		return "", fmt.Errorf("failed to convert job descroption to markdown (job id: %s): %w", job.ID, err)
+	}
+
+	return b.String(), nil
 }
 
 func (job *Job) save(db *sqlx.DB) (sql.Result, error) {
@@ -86,8 +114,10 @@ func (newJob *NewJob) validate(update bool) map[string]string {
 		errs["url"] = "Must provide either a Url or a Description"
 	}
 
-	if _, err := url.ParseRequestURI(newJob.Url); err != nil {
-		errs["url"] = "Must provide a valid Url"
+	if newJob.Description == "" {
+		if _, err := url.ParseRequestURI(newJob.Url); err != nil {
+			errs["url"] = "Must provide a valid Url"
+		}
 	}
 
 	if !update {

--- a/data.go
+++ b/data.go
@@ -14,9 +14,6 @@ import (
 	"github.com/yuin/goldmark/extension"
 )
 
-// data
-// -------------------------------------
-
 type Job struct {
 	ID           string         `db:"id"`
 	Position     string         `db:"position"`

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/yuin/goldmark v1.4.8 // indirect
 	go.uber.org/atomic v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c // indirect

--- a/go.sum
+++ b/go.sum
@@ -932,6 +932,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.8 h1:zHPiabbIRssZOI0MAzJDHsyvG4MXCGqVaMOwR+HeoQQ=
+github.com/yuin/goldmark v1.4.8/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=

--- a/routes.go
+++ b/routes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"html/template"
 	"log"
 
 	"github.com/gin-contrib/sessions"
@@ -157,7 +158,14 @@ func (ctrl *Controller) ViewJob(ctx *gin.Context) {
 	if err != nil {
 		panic(err) // TODO: err
 	}
-	ctx.HTML(200, "view", gin.H{"job": job})
+
+	description, err := job.RenderDescription()
+	if err != nil {
+		log.Println("failed to render job description as markdown: %w", err)
+		description = job.Description.String
+	}
+
+	ctx.HTML(200, "view", gin.H{"job": job, "description": template.HTML(description)})
 }
 
 func addFlash(ctx *gin.Context, base gin.H) gin.H {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   {{ range .jobs }}
     <li class="flex mb-2 p-4 relative border-b sm:border-b-0 last:border-b-0 hover:bg-blue-100 group sm:rounded-lg">
       <div class="w-full sm:pr-16">
-        <h2 class="font-bold text-lg">{{ .Position }}</h2>
+        <h2 class="m-0 font-bold text-lg">{{ .Position }}</h2>
         <div>{{ .Organization }}</div>
         <a
             href="/jobs/{{ .ID }}"

--- a/templates/view.html
+++ b/templates/view.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
   <h2 class="font-bold text-lg">{{ .job.Position }}</h2>
   <div class="mb-6">{{ .job.Organization }}</div>
-  <div class="mb-6">{{ .description }}</div><!-- TODO: format better -->
+  <div class="mb-6">{{ .description }}</div>
   {{ if .job.Url.Valid }}
   <div class="mb-6">
     <a href="{{ .job.Url.String }}" target="_blank" class="btn btn-primary">

--- a/templates/view.html
+++ b/templates/view.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
   <h2 class="font-bold text-lg">{{ .job.Position }}</h2>
   <div class="mb-6">{{ .job.Organization }}</div>
-  <div class="mb-6">{{ .job.Description.String }}</div><!-- TODO: format better -->
+  <div class="mb-6">{{ .description }}</div><!-- TODO: format better -->
   {{ if .job.Url.Valid }}
   <div class="mb-6">
     <a href="{{ .job.Url.String }}" target="_blank" class="btn btn-primary">

--- a/templates/view.html
+++ b/templates/view.html
@@ -1,7 +1,10 @@
 {{ define "content" }}
-  <h2 class="font-bold text-lg">{{ .job.Position }}</h2>
+  <h2 class="m-0 font-bold text-lg">{{ .job.Position }}</h2>
   <div class="mb-6">{{ .job.Organization }}</div>
-  <div class="mb-6">{{ .description }}</div>
+  {{ if.job.Description.Valid }}
+    <hr>
+    <div class="mb-6">{{ .description }}</div>
+  {{ end }}
   {{ if .job.Url.Valid }}
   <div class="mb-6">
     <a href="{{ .job.Url.String }}" target="_blank" class="btn btn-primary">


### PR DESCRIPTION
Renders job description field as markdown if available, fallback to plain text if render fails.

Made some style adjustments, outside of tailwind accepted patterns, to put some default styling on rendered markdown back in place. Not proud of it, but :shrug:

Closes #9

Closes #8
