### PR TITLE
database seed tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: psql
 psql:
 	docker compose exec db psql "postgresql://jobs:supsupsup@localhost:5432/jobs"
+
+.PHONY: seed-db
+seed-db:
+	docker compose exec app go run ./cmd/dbseeder/main.go

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ a go rewrite of the original [devICT job board](https://github.com/devict/jobs.d
 
 ## running locally
 
-```
+```shell
 $ docker compose up
 ```
 
 ## accessing the database
 
-```
+```shell
 $ make psql
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ $ docker compose up
 $ make psql
 ```
 
+## seed the database with test data
+
+```shell
+$ make seed-db
+```
+
 ## slack integration
 
 setting the `SLACK_HOOK` env var will enable posting new jobs to Slack to the provided Slack hook url. if not configured, this functionality will simply be disabled

--- a/cmd/dbseeder/lorem/lorem.go
+++ b/cmd/dbseeder/lorem/lorem.go
@@ -1,0 +1,106 @@
+package lorem
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+func init() {
+	w := map[string]bool{}
+	for i := range words {
+		if _, ok := w[words[i]]; ok {
+			panic(fmt.Sprintf("duplicate word: %s", words[i]))
+		}
+		w[words[i]] = true
+	}
+}
+
+var words = [...]string{"atmospheric", "then", "nonfungible", "actionable", "wholesome", "visibility", "insights", "disrupt", "database", "dramatic", "must", "market", "elevate", "days", "weeks", "week", "collaborate", "meta", "tesla", "bottom-line", "isomer", "people", "parks", "semantic", "ergo", "because", "which", "therefor", "remote", "unique", "web 3.0", "synergy", "clicks-and-mortar", "golang", "360-degree", "target", "uniquely", "project", "proactive", "agile", "domination", "key", "quickly", "continually", "wireless", "rapaciously", "thinking", "expertise", "synergistically", "tactical", "line", "compelling", "implement", "cross-unit", "core", "expedite", "distinctive", "leverage", "organically", "workflows", "installed", "base", "compliant", "reintermediate", "robust", "end", "directed", "functional", "others", "offshoring", "long-term", "close", "podcasting", "networks", "resource-leveling", "an", "outsourcing", "capitalize", "state", "granular", "premium", "items", "and", "procrastinate", "empower", "assertively", "expanded", "generate", "ballpark", "eye", "sound", "bricks-and-clicks", "effective", "view", "workplace", "your", "roi", "other", "by", "frameworks", "inside", "high-impact", "pontificate", "procedures", "fully", "theme", "communicate", "leadership", "evolved", "testing", "low-risk", "learn", "scale", "array", "digital", "cross-platform", "offline", "on", "override", "clickthroughs", "completely", "multimedia", "bleeding-edge", "maximizing", "functionalized", "for", "proposition", "underwhelm", "monotonically", "service", "web-readiness", "opportunities", "inexpensive", "build", "corporate", "manufactured", "via", "content", "e-tailers", "cost", "strategies", "nanotechnology", "resource", "whereas", "alignments", "unleash", "cross-media", "art", "envisioned", "fabricate", "framework", "superior", "idea-sharing", "maximise", "coordinate", "disruptive", "immersion", "information", "high-yield", "high", "normal", "in", "with", "holisticly", "process-centric", "competently", "integration", "ideas", "competencies", "provide", "collaborative", "timely", "quality", "embrace", "frictionless", "level", "relationships", "high-payoff", "deploy", "prospective", "reinvent", "multiple", "based", "covalent", "standardized", "has", "benefits", "engage", "scalable", "vectors", "whiteboard", "heading", "experiences", "applications", "deliver", "enable", "fruit", "researched", "plagiarize", "compellingly", "principle-centered", "focused", "next-generation", "is", "products", "enabled", "identify", "incubate", "e-business", "interfaces", "e-commerce", "technically", "foster", "at", "interactively", "adaptive", "distinctively", "progressively", "appropriately", "mentality", "actualize", "methods", "matrix", "going", "added", "pursue", "top-line", "virtual", "initiatives", "additional", "focusing", "markets", "proactively", "results", "taking", "market-driven", "seamless", "after", "visionary", "further", "integrated", "diverse", "long", "evolve", "customer", "credibly", "best", "bottom", "premier", "web", "infrastructures", "enterprise", "mailchimp", "loop", "runway", "performing", "transparent", "that", "backend", "customized", "or", "re-engineer", "process", "metrics", "data", "accurate", "intrinsically", "productize", "cooperative", "generation", "highway", "time", "client-centric", "myocardinate", "cultivate", "solutions", "iterate", "infomediaries", "client-focused", "existing", "towards", "before", "without", "phosfluorescently", "turnkey", "vertical", "integrate", "strategy", "of", "web-enabled", "approaches", "empowered", "synthesize", "skills", "business", "ubiquitous", "plug-and-play", "efficiently", "indicators", "users", "dynamically", "dramatically", "maximize", "one-to-one", "objectively", "task", "paradigms", "table", "streamlined", "energistically", "iterative", "niche", "growth", "intellectual", "imperatives", "incentivize", "network", "overviews", "value", "holistic", "cloud", "user", "schemas", "innovate", "initiate", "about", "practices", "processes", "exploit", "areas", "from", "synergize", "outside", "models", "just", "materials", "world-class", "world", "establish", "through", "sustainable", "optimal", "technologies", "distributed", "devops", "holistically", "user-centric", "diversity", "solution", "potentialities", "divide", "leading-edge", "management", "aggregate", "touchpoints", "backward-compatible", "technology", "to", "deliverables", "economically", "empowerment", "interoperable", "ethical", "tested", "the", "change", "chains", "vis-a-vis", "scenarios", "win-win", "generated", "have", "drive", "rather", "cutting-edge", "box", "interdependent", "improvements", "ball", "standards", "innovation", "day", "future-proof", "strategic", "friendly", "start-up", "worldwide", "sources", "disseminate", "meta-services", "action", "taxing", "extensive", "dynamic", "more", "derive", "seize", "emerging", "overall", "forward", "hanging", "dive", "platforms", "utilize", "reconceptualize", "enthusiastically", "operational", "convergence", "visualize", "capital", "evisculate", "harness", "maintain", "ensure", "along", "extensible", "seamlessly", "niches", "organic", "survival", "performance", "keeping", "collaboration", "than", "front-end", "inter-mandated", "beta", "tail", "while", "deep", "intuitive", "communities", "fashion", "professionally", "predominate", "bring", "will", "collaboratively", "supply", "portals", "mesh", "this", "enterprise-wide", "synopsis", "bandwidth", "highly", "solely", "administrate", "revolutionary", "parallel", "reliable", "architectures", "revolutionize", "grow", "internal", "impactful", "globally", "interactive", "sponsored", "new", "real-time", "test", "methodologies", "channels", "e-markets", "global", "open-source", "low", "activity", "services", "maintainable", "e-services", "catalysts", "efficient"}
+var punctuation = [...]string{".", "!", "?"}
+
+func Word() string {
+	i, err := rand.Int(rand.Reader, big.NewInt(int64(len(words))))
+	if err != nil {
+		panic(err)
+	}
+	return words[i.Int64()]
+}
+
+func WordsN(n int) string {
+	w := make([]string, n)
+	for i := 0; i < n; i++ {
+		w[i] = Word()
+	}
+
+	return strings.Join(w, " ")
+}
+
+func WordsRange(min, max int) string {
+	numWords, err := rand.Int(rand.Reader, big.NewInt(int64(max-1)))
+	if err != nil {
+		panic(err)
+	}
+
+	n := numWords.Int64() + int64(min)
+
+	w := make([]string, n)
+	for i := int64(0); i < n; i++ {
+		w[i] = Word()
+	}
+
+	return strings.Join(w, " ")
+}
+
+func Sentence() string {
+	l, err := rand.Int(rand.Reader, big.NewInt(int64(20)))
+	if err != nil {
+		panic(err)
+	}
+
+	length := l.Int64() + 1
+
+	w := strings.Split(WordsN(int(length)), " ")
+	w[0] = strings.Title(w[0])
+
+	i, err := rand.Int(rand.Reader, big.NewInt(int64(len(punctuation))))
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Join(w, " ") + punctuation[i.Int64()]
+}
+
+func Paragraph() string {
+	l, err := rand.Int(rand.Reader, big.NewInt(int64(6)))
+	if err != nil {
+		panic(err)
+	}
+
+	length := l.Int64() + 1
+
+	s := make([]string, length)
+	for i := 0; i < int(length); i++ {
+		s[i] = Sentence()
+	}
+
+	return strings.Join(s, " ")
+}
+
+func ParagraphsN(n int) string {
+	p := make([]string, n)
+	for i := 0; i < n; i++ {
+		p[i] = Paragraph()
+	}
+
+	return strings.Join(p, "\n\n")
+}
+
+func URL() string {
+	return fmt.Sprintf("https://%s.com/%s", Word(), Word())
+}
+
+func Email() string {
+	return fmt.Sprintf("%s.%s@%s.com", Word(), Word(), Word())
+}

--- a/cmd/dbseeder/main.go
+++ b/cmd/dbseeder/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+
+	"github.com/devict/job-board/cmd/dbseeder/lorem"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalln("main failed to run:", err)
+	}
+
+	log.Println("success!")
+}
+
+func run() error {
+	db, err := sqlx.Open("postgres", fmt.Sprintf("%s%s", os.Getenv("DATABASE_URL"), "?sslmode=disable"))
+	if err != nil {
+		return fmt.Errorf("failed to sqlx.Open: %w", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("failed to Ping: %w", err)
+	}
+
+	type Job struct {
+		// ID           string         `db:"id"`
+		Position     string         `db:"position"`
+		Organization string         `db:"organization"`
+		Url          sql.NullString `db:"url"`
+		Description  sql.NullString `db:"description"`
+		Email        string         `db:"email"`
+		// PublishedAt  time.Time      `db:"published_at"`
+	}
+
+	for i := 0; i < 50; i++ {
+		j := Job{
+			Position:     lorem.WordsRange(1, 3),
+			Organization: lorem.WordsRange(2, 4),
+			Url:          sql.NullString{String: lorem.URL(), Valid: i%20 == 0},
+			Description:  sql.NullString{String: lorem.ParagraphsN(3), Valid: i%40 == 0},
+			Email:        lorem.Email(),
+		}
+
+		q := `
+		INSERT INTO jobs
+			(
+				position,
+				organization,
+				url,
+				description,
+				email,
+				published_at
+			)
+		VALUES
+			(
+				:position,
+				:organization,
+				:url,
+				:description,
+				:email,
+				NOW() - JUSTIFY_INTERVAL(RANDOM() * INTERVAL '60 days')
+			)
+		`
+
+		if _, err := db.NamedExec(q, j); err != nil {
+			return fmt.Errorf("failed to Exec: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/dbseeder/main.go
+++ b/cmd/dbseeder/main.go
@@ -21,6 +21,10 @@ func main() {
 }
 
 func run() error {
+	if os.Getenv("APP_ENV") != "debug" {
+		return fmt.Errorf("must not run in environment: %q", os.Getenv("APP_ENV"))
+	}
+
 	db, err := sqlx.Open("postgres", fmt.Sprintf("%s%s", os.Getenv("DATABASE_URL"), "?sslmode=disable"))
 	if err != nil {
 		return fmt.Errorf("failed to sqlx.Open: %w", err)


### PR DESCRIPTION
Closes #20 

Added a seeding tool, had a little fun with it. Unnecessarily cryptographically random jargon generator.

There's a little bit of copy-paste with the Job struct. Theoretically, the tool could just use the one defined in the server, but everything is in package `main` there. May come back later to do some refactoring. I don't think there's much danger in this drifting for now.