### PR TITLE
Run worker first and fix seeder

### DIFF
--- a/cmd/dbseeder/main.go
+++ b/cmd/dbseeder/main.go
@@ -48,8 +48,8 @@ func run() error {
 		j := Job{
 			Position:     lorem.WordsRange(1, 3),
 			Organization: lorem.WordsRange(2, 4),
-			Url:          sql.NullString{String: lorem.URL(), Valid: i%20 == 0},
-			Description:  sql.NullString{String: lorem.ParagraphsN(3), Valid: i%40 == 0},
+			Url:          sql.NullString{String: lorem.URL(), Valid: i%20 != 0},
+			Description:  sql.NullString{String: lorem.ParagraphsN(3), Valid: i%40 != 0},
 			Email:        lorem.Email(),
 		}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -61,15 +61,18 @@ func run() error {
 		defer ticker.Stop()
 
 		for {
+			log.Println("removing old jobs")
+			_, err := db.Exec("DELETE FROM jobs WHERE published_at < NOW() - INTERVAL '30 DAYS'")
+			if err != nil {
+				log.Println(fmt.Errorf("error clearing old jobs: %w", err))
+			}
+
 			select {
 			case <-ctx.Done():
 				log.Println("shutting down old jobs background process")
 				return
 			case <-ticker.C:
-				_, err := db.Exec("DELETE FROM jobs WHERE published_at < NOW() - INTERVAL '30 DAYS'")
-				if err != nil {
-					log.Println(fmt.Errorf("error clearing old jobs: %w", err))
-				}
+				continue
 			}
 		}
 	}()


### PR DESCRIPTION
Closes #22 

The worker now runs at startup and every tick (hour in this case) after that.

I made a mistake on the seeder and did the opposite of what I wanted, so I fixed that.