### PR TITLE
Add an about page

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -36,6 +36,10 @@ func (ctrl *Controller) Index(ctx *gin.Context) {
 	}))
 }
 
+func (ctrl *Controller) About(ctx *gin.Context) {
+	ctx.HTML(200, "about", gin.H{})
+}
+
 func (ctrl *Controller) NewJob(ctx *gin.Context) {
 	session := sessions.Default(ctx)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -62,6 +62,7 @@ func NewServer(c *ServerConfig) (http.Server, error) {
 		TwitterService: c.TwitterService,
 	}
 	router.GET("/", ctrl.Index)
+	router.GET("/about", ctrl.About)
 	router.GET("/new", ctrl.NewJob)
 	router.POST("/jobs", ctrl.CreateJob)
 	router.GET("/jobs/:id", ctrl.ViewJob)
@@ -89,6 +90,7 @@ func renderer(templatePath string) multitemplate.Renderer {
 
 	r := multitemplate.NewRenderer()
 	r.AddFromFilesFuncs("index", funcMap, basePath, path.Join(templatePath, "index.html"))
+	r.AddFromFilesFuncs("about", funcMap, basePath, path.Join(templatePath, "about.html"))
 	r.AddFromFilesFuncs("new", funcMap, basePath, path.Join(templatePath, "new.html"))
 	r.AddFromFilesFuncs("edit", funcMap, basePath, path.Join(templatePath, "edit.html"))
 	r.AddFromFilesFuncs("view", funcMap, basePath, path.Join(templatePath, "view.html"))

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,8 +1,10 @@
 {{ define "content" }}
 <h2 class="m-0 font-bold text-lg">About this job board</h2>
 <div class="mb-6">
-  <p>This job board is run by <a href="https://devict.org" title="devICT">devICT</a> a community group for software and
-    web developers in Wichita, KS.</p>
+  <p>
+    This job board is run by <a href="https://devict.org" title="devICT">devICT</a>, a community group for software devs
+    and tech professionals in Wichita, KS.
+  </p>
   <p>
     In general, the jobs posted here should be connected to Wichita in some way, and be tech or software related in some
     way.
@@ -15,6 +17,11 @@
   <p>
     The goal is to avoid individuals / companies with no tie to the region from dropping random listings here. There are
     plenty of other job boards out there for that!
+  </p>
+  <p>
+    Jobs posted here automatically are shared in the
+    <a href="https://slack.devict.org" title="devICT Slack">devICT Slack's #job-postings channel</a>.
+    If you have any additional questions, <a href="https://slack.devict.org" title="devICT Slack">join us in slack</a> and ask away!.
   </p>
 </div>
 {{ end }}

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,20 @@
+{{ define "content" }}
+<h2 class="m-0 font-bold text-lg">About this job board</h2>
+<div class="mb-6">
+  <p>This job board is run by <a href="https://devict.org" title="devICT">devICT</a> a community group for software and
+    web developers in Wichita, KS.</p>
+  <p>
+    In general, the jobs posted here should be connected to Wichita in some way, and be tech or software related in some
+    way.
+    This can include job opportunities for tech employers in the region and non-regional employers with local employees.
+  </p>
+  <p>
+    Job postings for non-regional employers that also do not have any local employees are fine <strong>as long as they
+      are posted by local commnuity members</strong>.
+  </p>
+  <p>
+    The goal is to avoid individuals / companies with no tie to the region from dropping random listings here. There are
+    plenty of other job boards out there for that!
+  </p>
+</div>
+{{ end }}

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,10 @@
         </a>
       </div>
     </header>
-    <main class="px-4 py-16 flex-1">
+    <div class="text-center w-full pt-4 font-bold text-sm">
+      <p><a href="/about">Questions?</a></p>
+    </div>
+    <main class="px-4 py-4 flex-1">
       <div class="max-w-lg mx-auto">
         {{ range .flashes }}
           <p>{{ . }}</p>
@@ -38,12 +41,10 @@
     </main>
     <footer class="footer-image text-center font-semibold">
       <p class="block text-center text-orange-500 mb-1">Made by
-      <a href="https://devict.org">
-        <img src="/assets/svg/devict-logo.svg" alt="devICT" class="h-5 inline-block mx-auto">
-      </a>
+        <a href="https://devict.org"><img src="/assets/svg/devict-logo.svg" alt="devICT" class="h-5 inline-block mx-auto"></a>
       <p>
       <p class="text-orange-500">
-      <a href="https://github.com/devict/job-board" class="underline hover:no-underline focus:no-underline">Contribute on GitHub</a>
+        <a href="https://github.com/devict/job-board" class="underline hover:no-underline focus:no-underline">Contribute on GitHub</a>
       </p>
     </footer>
   </body>


### PR DESCRIPTION
This PR adds an `/about` route with a link to it under the "Post a job" button.

The goal is to provide some basic information about the intent of this job board and its regional focus.

Additional useful information can be added here in the future as well.
