### PR TITLE
[Update] GitHub deploy actions to newer node version

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -3,8 +3,8 @@ description: Run CI checks
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
         go-version: 1.23
     - shell: bash

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: 1.23
     - shell: bash

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -7,5 +7,5 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/check
       - uses: superfly/flyctl-actions@1.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,20 +10,20 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/check
       - uses: superfly/flyctl-actions@1.1
         with:
           args: "deploy"
       - if: success()
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |
             {
               "text": "deployed <https://github.com/${{ github.repository }}/commit/${{ github.sha}}|${{ github.sha }}>"
             }
       - if: failure()
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |
             {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,14 +16,14 @@ jobs:
         with:
           args: "deploy"
       - if: success()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
             {
               "text": "deployed <https://github.com/${{ github.repository }}/commit/${{ github.sha}}|${{ github.sha }}>"
             }
       - if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
             {


### PR DESCRIPTION
# Fix #38   

This pull request includes updates to the GitHub Actions workflow configuration file to ensure compatibility with newer versions of actions and improve the deployment process.

Updates to GitHub Actions workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L13-R26): Updated `actions/checkout` from version `v2` to `v3` to use the latest features and improvements.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L13-R26): Updated `slackapi/slack-github-action` from version `v1.18.0` to `v1.24.0` to benefit from the latest bug fixes and enhancements.