### PR TITLE
Updated Go to the latest version(1.23)

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.23
     - shell: bash
       run: make build
     - shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.23 as builder
 RUN mkdir /app
 WORKDIR /app
 COPY . .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.18 as build
+FROM golang:1.23 as build
 RUN go install github.com/cortesi/modd/cmd/modd@latest
 WORKDIR /app
 COPY go.mod .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devict/job-board
 
-go 1.18
+go 1.23
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
# Closes #37 
This pull request includes updates to the Go version used across various files in the project to ensure consistency and compatibility with the latest features and improvements in Go 1.23. The most important changes are listed below:

Go version updates:

* [`.github/actions/check/action.yml`](diffhunk://#diff-99b87178e201388c0ebfd7d8584c9f6930100d335919c10b7399b39a88cb0c03L9-R9): Updated the `setup-go` action to use Go version 1.23.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Changed the base image to use Go version 1.23.
* [`Dockerfile.dev`](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL1-R1): Changed the base image to use Go version 1.23.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version requirement to 1.23.